### PR TITLE
improve speach time response accuracy.

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -22,8 +22,8 @@ RUN powershell -NoProfile -ExecutionPolicy Bypass -Command \
     "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; \
      iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))"
 
-ARG CMAKE_VERSION=4.3.1
-ARG GIT_VERSION=2.53.0
+ARG CMAKE_VERSION=4.3.2
+ARG GIT_VERSION=2.54.0
 ARG WGET_VERSION=1.21.4
 ARG UNZIP_VERSION=6.0
 ARG STRAWBERRYPERL_VERSION=5.38.2.2

--- a/dcs/Mods/Services/HoundTTS/Scripts/HoundTTS-mission.lua
+++ b/dcs/Mods/Services/HoundTTS/Scripts/HoundTTS-mission.lua
@@ -157,7 +157,7 @@ local function updateTrackedSessions(_,time)
     for sessionId, dcsObject in pairs(tracked_sessions) do
         if isDcsUnit(dcsObject) or isStaticObject(dcsObject) then
             if dcsObject:isExist() and dcsObject:getLife() >= 1 then
-                local alive = HoundTTS.UpdateSession(sessionId,{point = getTransmitterPos(dcsObject)})
+                local alive = HoundTTS.UpdateSession(sessionId,{point = isDcsUnit(dcsObject) and getTransmitterPos(dcsObject) or nil})
                 if not alive then
                     table.insert(toRemove, {sessionId, true})
                 end
@@ -496,9 +496,6 @@ end
 -- sessionId    : string — returned by Transmit / TransmitNoise / TransmitTone
 -- update_params (table):
 --   .point      DCS Vec3 (optional) — new transmitter position
---   .lat        number  (optional) — explicit lat/lon/alt (overrides .point)
---   .lon        number
---   .alt        number
 --
 -- Returns true if the session is still alive (transmission ongoing).
 -- Returns false if the session was not found OR the transmission has ended
@@ -517,25 +514,13 @@ function HoundTTS.UpdateSession(sessionId, update_params)
     if not sessionId then return false end
     local up = update_params or {}
 
-    local lat, lon, alt
-
-    -- Start from point if provided
-    if isPoint(up.point) then
-        lat, lon, alt = coord.LOtoLL(up.point)
-        lat = HoundTTS.round(lat, 4)
-        lon = HoundTTS.round(lon, 4)
-        alt = math.ceil(alt)
-    end
-
-    -- Explicit coordinates override point-derived values (partial overrides OK)
-    if up.lat then lat = up.lat end
-    if up.lon then lon = up.lon end
-    if up.alt then alt = up.alt end
-
     local updateTbl = {}
-    if lat ~= nil then updateTbl.lat = lat end
-    if lon ~= nil then updateTbl.lon = lon end
-    if alt ~= nil then updateTbl.alt = alt end
+    if isPoint(up.point) then
+        local lat, lon, alt = getCoords(up.point)
+        updateTbl.lat = lat
+        updateTbl.lon = lon
+        updateTbl.alt = alt
+    end
 
     -- _dll.updateSession returns:
     --   true  — session found and still alive

--- a/deps.env
+++ b/deps.env
@@ -4,8 +4,8 @@
 # changed layer (and everything after it) is invalidated on rebuild.
 # Last verified: 2026-04-08
 
-CMAKE_VERSION=4.3.1
-GIT_VERSION=2.53.0
+CMAKE_VERSION=4.3.2
+GIT_VERSION=2.54.0
 WGET_VERSION=1.21.4
 UNZIP_VERSION=6.0
 STRAWBERRYPERL_VERSION=5.38.2.2

--- a/src/lua_tts.cpp
+++ b/src/lua_tts.cpp
@@ -234,12 +234,25 @@ int l_textToSpeech(lua_State* L) {
         b->Transmit(pcmQueue, txParams);
     }).detach();
 
-    double speed = req.speed;
-    if (speed <= -999.0)
-        speed = (provider == HoundTTS::TtsProvider::Sapi) ? 0.0 : 1.0;
+    // Exact duration on cache hit, heuristic estimate on miss.
+    // Peek is cheap (mutex + map lookup); TTSPipeline::Produce will re-check
+    // on the detached thread independently.
+    double speechTime = -1.0;
+    if (req.message != "__test_tone__") {
+        uint64_t cacheKey = HoundTTS::ComputeTTSRequestKey(req);
+        auto cached = HoundTTS::PCMCache::Instance().Get(cacheKey);
+        if (cached) {
+            speechTime = static_cast<double>(cached->size()) / 16000.0;
+        }
+    }
+    if (speechTime < 0.0) {
+        double speed = req.speed;
+        if (speed <= -999.0)
+            speed = (provider == HoundTTS::TtsProvider::Sapi) ? 0.0 : 1.0;
+        speechTime = HoundTTS::GetSpeechTime(
+            static_cast<int>(req.message.size()), speed, provider);
+    }
 
-    double speechTime = HoundTTS::GetSpeechTime(
-        static_cast<int>(req.message.size()), speed, provider);
     lua_pushnumber(L, speechTime);
     lua_pushstring(L, sessionId.c_str());
     return 2;
@@ -313,8 +326,7 @@ int l_startNoise(lua_State* L) {
     std::string modulations = GetTableString(L, 1, "modulations", "AM");
     int         coalition   = GetTableInt   (L, 1, "coalition",   0);
     std::string name        = GetTableString(L, 1, "name",        "HoundTTS-Jammer");
-    bool        encrypt     = GetTableBool  (L, 1, "encrypt",     false);
-    int         encKey      = GetTableInt   (L, 1, "encKey",      0);
+    // encrypt/encKey intentionally not read from Lua — noise is never encrypted
     double      lat         = GetTableNumber(L, 1, "lat",         91.0);
     double      lon         = GetTableNumber(L, 1, "lon",         181.0);
     double      alt         = GetTableNumber(L, 1, "alt",         -500.0);
@@ -352,8 +364,8 @@ int l_startNoise(lua_State* L) {
     txParams.port        = port;
     txParams.freqs       = expandedFreqs;
     txParams.modulations = expandedMods;
-    txParams.encrypt     = encrypt;
-    txParams.encKey      = static_cast<uint8_t>(encKey);
+    txParams.encrypt     = false;  // noise is never encrypted (encryption would just garble the noise)
+    txParams.encKey      = 0;
     txParams.coalition   = coalition;
     txParams.name        = name;
     txParams.lat         = lat;
@@ -402,8 +414,7 @@ int l_startTone(lua_State* L) {
     std::string modulations = GetTableString(L, 1, "modulations", "AM");
     int         coalition   = GetTableInt   (L, 1, "coalition",   0);
     std::string name        = GetTableString(L, 1, "name",        "HoundTTS-Tone");
-    bool        encrypt     = GetTableBool  (L, 1, "encrypt",     false);
-    int         encKey      = GetTableInt   (L, 1, "encKey",      0);
+    // encrypt/encKey intentionally not read from Lua — tone is never encrypted
     double      lat         = GetTableNumber(L, 1, "lat",         91.0);
     double      lon         = GetTableNumber(L, 1, "lon",         181.0);
     double      alt         = GetTableNumber(L, 1, "alt",         -500.0);
@@ -423,8 +434,8 @@ int l_startTone(lua_State* L) {
     txParams.port        = port;
     txParams.freqs       = freqs;
     txParams.modulations = modulations;
-    txParams.encrypt     = encrypt;
-    txParams.encKey      = static_cast<uint8_t>(encKey);
+    txParams.encrypt     = false; // Tone should not be encrypted
+    txParams.encKey      = 0;
     txParams.coalition   = coalition;
     txParams.name        = name;
     txParams.lat         = lat;
@@ -462,11 +473,13 @@ int l_startTone(lua_State* L) {
 //          nil   if session not found
 // ---------------------------------------------------------------------------
 int l_updateSession(lua_State* L) {
+    auto& log = HoundTTS::Logger::Instance();
     const char* id = luaL_checkstring(L, 1);
     luaL_checktype(L, 2, LUA_TTABLE);
 
     auto session = HoundTTS::SessionManager::Instance().Get(std::string(id));
     if (!session) {
+        log.Debug("updateSession", "session not found: " + std::string(id));
         lua_pushnil(L);
         return 1;
     }
@@ -477,17 +490,25 @@ int l_updateSession(lua_State* L) {
       posData = std::static_pointer_cast<HoundTTS::SRSPositionData>(session->backendData); }
     if (posData) {
         bool hasPos = false;
+        double newLat = 0, newLon = 0, newAlt = 0;
         lua_getfield(L, 2, "lat");
-        if (lua_isnumber(L, -1)) { posData->lat.store(lua_tonumber(L, -1)); hasPos = true; }
+        if (lua_isnumber(L, -1)) { newLat = lua_tonumber(L, -1); posData->lat.store(newLat); hasPos = true; }
         lua_pop(L, 1);
 
         lua_getfield(L, 2, "lon");
-        if (lua_isnumber(L, -1)) { posData->lon.store(lua_tonumber(L, -1)); hasPos = true; }
+        if (lua_isnumber(L, -1)) { newLon = lua_tonumber(L, -1); posData->lon.store(newLon); hasPos = true; }
         lua_pop(L, 1);
 
         lua_getfield(L, 2, "alt");
-        if (lua_isnumber(L, -1)) { posData->alt.store(lua_tonumber(L, -1)); hasPos = true; }
+        if (lua_isnumber(L, -1)) { newAlt = lua_tonumber(L, -1); posData->alt.store(newAlt); hasPos = true; }
         lua_pop(L, 1);
+
+        if (hasPos) {
+            log.Debug("updateSession", "session " + std::string(id)
+                      + " position: lat=" + std::to_string(newLat)
+                      + " lon=" + std::to_string(newLon)
+                      + " alt=" + std::to_string(newAlt));
+        }
 
         // If any position field changed and a sync callback is registered, fire it immediately.
         // Invoke under syncMutex so the SRSClient teardown (which also acquires
@@ -508,11 +529,15 @@ int l_updateSession(lua_State* L) {
     lua_getfield(L, 2, "alive");
     if (lua_isboolean(L, -1) && !lua_toboolean(L, -1)) {
         session->alive.store(false);
+        log.Debug("updateSession", "session " + std::string(id) + " killed");
     }
     lua_pop(L, 1);
 
+    bool alive = session->alive.load();
+    log.Debug("updateSession", "session " + std::string(id) + " updated, alive=" + (alive ? "true" : "false"));
+
     // Return alive state — false signals the transmission has ended (naturally or killed)
-    lua_pushboolean(L, session->alive.load() ? 1 : 0);
+    lua_pushboolean(L, alive ? 1 : 0);
     return 1;
 }
 

--- a/src/speech_time.h
+++ b/src/speech_time.h
@@ -30,13 +30,22 @@ inline double GetSpeechTime(int length, double speed = 1.0,
             }
         }
         break;
+    case TtsProvider::Piper:
+        // Piper: length_scale = 1/speed, so speed=2 → 2x faster.
+        // Clamp to sane range to avoid division issues.
+        speedFactor = std::max(0.1, std::min(10.0, speed));
+        break;
     case TtsProvider::ElevenLabs:
-        // ElevenLabs: direct multiplier, clamped to 0.7–1.2
+        // ElevenLabs: direct multiplier, clamped 0.7–1.2
         speedFactor = std::max(0.7, std::min(1.2, speed));
         break;
-    case TtsProvider::Piper:
-        // Piper: speed is ignored by the engine
-        speedFactor = 1.0;
+    case TtsProvider::Google:
+        // Google: speakingRate, clamped 0.25–4.0
+        speedFactor = std::max(0.25, std::min(4.0, speed));
+        break;
+    case TtsProvider::AWS:
+        // AWS Polly: SSML prosody rate, clamped 0.2–2.0
+        speedFactor = std::max(0.2, std::min(2.0, speed));
         break;
     case TtsProvider::KittenTTS:
         // KittenTTS: direct speed multiplier (0.1–4.0)
@@ -47,7 +56,7 @@ inline double GetSpeechTime(int length, double speed = 1.0,
         speedFactor = std::max(0.25, std::min(4.0, speed));
         break;
     default:
-        // Google, Azure, AWS, Unknown: direct multiplier
+        // Azure, Unknown: direct multiplier
         speedFactor = speed;
         break;
     }


### PR DESCRIPTION
* Improve accuracy of speech time function. better speed factor compensation and returning true output length for cached results.
* add debug logging to updateSession
* fix Lua mission script to work correctly with dcsObjects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Use cached audio size to compute speech duration when available
  * Always send positional info only for unit objects; avoid partial coordinate overrides
  * Ensure noise/tone transmissions are sent without encryption
  * Improve provider-specific speed handling and add session update logging

* **Chores**
  * Updated build tool versions (CMake, Git)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->