### PR TITLE
feat: two-step SRS handshake with EAM password support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,9 @@ find_package(OpenSSL REQUIRED)
 set(OPENSSL_SSL_LIB OpenSSL::SSL)
 set(OPENSSL_CRYPTO_LIB OpenSSL::Crypto)
 
+# --- nlohmann-json (for parsing SRS handshake replies) ---
+find_package(nlohmann_json REQUIRED)
+
 # --- Version resource (right-click → Properties → Details) ---
 configure_file(
     "${CMAKE_SOURCE_DIR}/src/version.rc.in"
@@ -144,6 +147,7 @@ target_link_libraries(HoundTTS PRIVATE
     ${OPUS_TARGET}
     ${OPENSSL_SSL_LIB}
     ${OPENSSL_CRYPTO_LIB}
+    nlohmann_json::nlohmann_json
     advapi32
     winmm
     ws2_32

--- a/dcs/Config/HoundTTS-config.lua.example
+++ b/dcs/Config/HoundTTS-config.lua.example
@@ -13,6 +13,13 @@ SRS_PORT    = 5002
 SRS_ENCRYPT = false
 SRS_ENC_KEY = 0
 
+-- SRS EAM (External AWACS Mode) passwords
+-- Required only if your SRS server has --enableEAM active.
+-- HoundTTS will automatically send the correct password for the coalition
+-- you specify in each transmission call.
+SRS_BLUE_PASSWORD = ""
+SRS_RED_PASSWORD  = ""
+
 DEFAULT_TRANSMITTER = "srs"
 
 -- Default TTS provider (used when transmitter = "srs"):

--- a/dcs/Mods/Services/HoundTTS/Scripts/HoundTTS-mission.lua
+++ b/dcs/Mods/Services/HoundTTS/Scripts/HoundTTS-mission.lua
@@ -61,6 +61,8 @@ HoundTTS.DEFAULT_VOICE       = HoundTTS.DEFAULT_VOICE       or ""
 HoundTTS.DEFAULT_SPEAKER     = HoundTTS.DEFAULT_SPEAKER     or ""
 HoundTTS.DEFAULT_CULTURE     = HoundTTS.DEFAULT_CULTURE     or "en-US"
 HoundTTS.DEFAULT_GENDER      = HoundTTS.DEFAULT_GENDER      or "female"
+HoundTTS.SRS_BLUE_PASSWORD   = HoundTTS.SRS_BLUE_PASSWORD   or ""
+HoundTTS.SRS_RED_PASSWORD    = HoundTTS.SRS_RED_PASSWORD    or ""
 
 -- -------------------------------------------------------------------------
 -- Load DLL before `require` gets sanitized
@@ -263,18 +265,20 @@ function HoundTTS.Transmit(message, transmission_params, provider_params, transl
     local result, sessionId = _dll.textToSpeech(
         message,
         {
-            transmitter = transmitter,
-            host        = host,
-            port        = port,
-            freqs       = freqs,
-            modulations = modulations,
-            coalition   = coalition,
-            name        = name,
-            encrypt     = encrypt,
-            encKey      = encKey,
-            lat         = lat,
-            lon         = lon,
-            alt         = alt,
+            transmitter        = transmitter,
+            host               = host,
+            port               = port,
+            freqs              = freqs,
+            modulations        = modulations,
+            coalition          = coalition,
+            name               = name,
+            encrypt            = encrypt,
+            encKey             = encKey,
+            lat                = lat,
+            lon                = lon,
+            alt                = alt,
+            srs_blue_password  = tp.srs_blue_password or HoundTTS.SRS_BLUE_PASSWORD or "",
+            srs_red_password   = tp.srs_red_password  or HoundTTS.SRS_RED_PASSWORD  or "",
         },
         {
             provider    = provider,
@@ -325,18 +329,20 @@ function HoundTTS.TextToSpeech(message, freqs, modulations, volume, name,
     local result = _dll.textToSpeech(
         message,
         {
-            transmitter = "srs",
-            host        = HoundTTS.SRS_HOST,
-            port        = HoundTTS.SRS_PORT,
-            freqs       = tostring(freqs),
-            modulations = tostring(modulations),
-            coalition   = coalition,
-            name        = name,
-            encrypt     = false,
-            encKey      = 0,
-            lat         = lat,
-            lon         = lon,
-            alt         = alt,
+            transmitter        = "srs",
+            host               = HoundTTS.SRS_HOST,
+            port               = HoundTTS.SRS_PORT,
+            freqs              = tostring(freqs),
+            modulations        = tostring(modulations),
+            coalition          = coalition,
+            name               = name,
+            encrypt            = false,
+            encKey             = 0,
+            lat                = lat,
+            lon                = lon,
+            alt                = alt,
+            srs_blue_password  = HoundTTS.SRS_BLUE_PASSWORD or "",
+            srs_red_password   = HoundTTS.SRS_RED_PASSWORD  or "",
         },
         {
             provider    = provider,
@@ -465,18 +471,20 @@ function HoundTTS.TransmitNoise(transmission_params, provider_params)
 
     local sessionId = _dll.startNoise(
         {
-            transmitter = transmitter,
-            host        = host,
-            port        = port,
-            freqs       = freqs,
-            modulations = modulations,
-            coalition   = coalition,
-            name        = name,
-            encrypt     = encrypt,
-            encKey      = encKey,
-            lat         = lat,
-            lon         = lon,
-            alt         = alt,
+            transmitter        = transmitter,
+            host               = host,
+            port               = port,
+            freqs              = freqs,
+            modulations        = modulations,
+            coalition          = coalition,
+            name               = name,
+            encrypt            = encrypt,
+            encKey             = encKey,
+            lat                = lat,
+            lon                = lon,
+            alt                = alt,
+            srs_blue_password  = tp.srs_blue_password or HoundTTS.SRS_BLUE_PASSWORD or "",
+            srs_red_password   = tp.srs_red_password  or HoundTTS.SRS_RED_PASSWORD  or "",
         },
         noiseParams
     )
@@ -605,18 +613,20 @@ function HoundTTS.TransmitTone(transmission_params, provider_params)
 
     local sessionId = _dll.startTone(
         {
-            transmitter = transmitter,
-            host        = host,
-            port        = port,
-            freqs       = freqs,
-            modulations = modulations,
-            coalition   = coalition,
-            name        = name,
-            encrypt     = encrypt,
-            encKey      = encKey,
-            lat         = lat,
-            lon         = lon,
-            alt         = alt,
+            transmitter        = transmitter,
+            host               = host,
+            port               = port,
+            freqs              = freqs,
+            modulations        = modulations,
+            coalition          = coalition,
+            name               = name,
+            encrypt            = encrypt,
+            encKey             = encKey,
+            lat                = lat,
+            lon                = lon,
+            alt                = alt,
+            srs_blue_password  = tp.srs_blue_password or HoundTTS.SRS_BLUE_PASSWORD or "",
+            srs_red_password   = tp.srs_red_password  or HoundTTS.SRS_RED_PASSWORD  or "",
         },
         { duration = duration, freqHz = freqHz, volume = volume }
     )

--- a/src/backend.h
+++ b/src/backend.h
@@ -25,6 +25,8 @@ struct TTSRequest {
     std::string srsHost;        // SRS server hostname/IP (default: localhost)
     bool        encrypt = false;
     int         encKey  = 0;    // Encryption key (0-255)
+    std::string srsBluePassword; // EAM password for blue coalition (2)
+    std::string srsRedPassword;  // EAM password for red coalition (1)
 
     // Content
     std::string message;
@@ -69,6 +71,8 @@ struct TransmitParams {
     uint8_t     encKey     = 0;
     int         coalition  = 0;
     std::string name;           // Transmitter name shown in SRS
+    std::string srsBluePassword; // EAM password for blue coalition (2)
+    std::string srsRedPassword;  // EAM password for red coalition (1)
     double      lat        = 91.0;
     double      lon        = 181.0;
     double      alt        = -500.0;

--- a/src/backends/srs/srs_backend.cpp
+++ b/src/backends/srs/srs_backend.cpp
@@ -29,6 +29,13 @@ bool SRSBackend::Transmit(std::shared_ptr<PCMQueue> pcm,
     uint32_t    unitId    = static_cast<uint32_t>(params.coalition);
     auto        session   = params.session;  // may be nullptr
 
+    // Select EAM password for the requested coalition
+    std::string eamPassword;
+    if (coalition == 2)
+        eamPassword = params.srsBluePassword;
+    else if (coalition == 1)
+        eamPassword = params.srsRedPassword;
+
     // Create and attach SRS-specific position data to the session
     std::shared_ptr<SRSPositionData> posData;
     if (session) {
@@ -40,7 +47,7 @@ bool SRSBackend::Transmit(std::shared_ptr<PCMQueue> pcm,
     }
 
     std::thread([pcm, host, port, freqs, coalition, name, unitId,
-                 session, posData]() {
+                 session, posData, eamPassword]() {
         // Opus-encode PCM as it arrives from the pipeline
         auto opusQueue = std::make_shared<AudioQueue>();
 
@@ -82,7 +89,7 @@ bool SRSBackend::Transmit(std::shared_ptr<PCMQueue> pcm,
             cleanup();
             return;
         }
-        if (!client.Handshake(coalition, name, freqs)) {
+        if (!client.Handshake(coalition, name, freqs, eamPassword)) {
             LogE("SRS handshake failed");
             client.Disconnect();
             cleanup();

--- a/src/backends/srs/srs_client.cpp
+++ b/src/backends/srs/srs_client.cpp
@@ -2,6 +2,7 @@
 #include <opus/opus.h>
 #include "srs_client.h"
 #include "utils.h"
+#include <nlohmann/json.hpp>
 
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -205,32 +206,112 @@ bool SRSClient::Connect(const std::string& host, int port) {
 }
 
 bool SRSClient::Handshake(int coalition, const std::string& name,
-                           const std::vector<FreqMod>& freqs) {
+                           const std::vector<FreqMod>& freqs,
+                           const std::string& eamPassword) {
     m_coalition = coalition;
     m_name      = name;
     std::string clientInfo = BuildClientInfoJson(coalition, name, freqs);
 
-    // Message type 2 = MessageSync
-    std::ostringstream sync;
-    sync << R"({"Version":")" << kSRSVersion << R"(","MsgType":2,"Client":)"
-         << clientInfo << "}";
-    if (!SendTCP(sync.str())) {
-        LogE("Handshake MsgType=2 send failed");
-        return false;
+    // Send SYNC (MsgType=2)
+    {
+        std::ostringstream sync;
+        sync << R"({"Version":")" << kSRSVersion << R"(","MsgType":2,"Client":)"
+             << clientInfo << "}";
+        if (!SendTCP(sync.str())) {
+            LogE("Handshake MsgType=2 send failed");
+            return false;
+        }
     }
 
-    // Message type 7 = MessageExternalAWACSModePassword (empty password)
-    std::ostringstream awacs;
-    awacs << R"({"Version":")" << kSRSVersion
-          << R"(","MsgType":7,"ExternalAWACSModePassword":"","Client":)"
-          << clientInfo << "}";
-    if (!SendTCP(awacs.str())) {
-        LogE("Handshake MsgType=7 send failed");
-        return false;
+    // Only read server response + attempt EAM password if a password is configured.
+    // Without a password there's nothing to send, so skip the TCP read entirely
+    // to avoid latency on the common case (no EAM).
+    if (!eamPassword.empty()) {
+        std::string syncResponse = ReadLine();
+        if (syncResponse.empty()) {
+            LogI("No SYNC response received (timeout/error) — proceeding without EAM");
+        } else {
+            // Parse server SYNC reply as JSON to check EAM status
+            bool eamEnabled = false;
+            try {
+                auto j = nlohmann::json::parse(syncResponse);
+                auto it = j.find("EXTERNAL_AWACS_MODE");
+                if (it != j.end() && it->is_string())
+                    eamEnabled = (it->get<std::string>() == "true");
+            } catch (...) {
+                LogI("Failed to parse SYNC response — assuming no EAM");
+            }
+
+            if (eamEnabled) {
+                std::ostringstream awacs;
+                awacs << R"({"Version":")" << kSRSVersion
+                      << R"(","MsgType":7,"ExternalAWACSModePassword":")"
+                      << EscapeJsonString(eamPassword) << R"(","Client":)"
+                      << clientInfo << "}";
+                if (!SendTCP(awacs.str())) {
+                    LogE("Handshake MsgType=7 send failed");
+                    return false;
+                }
+
+                std::string pwResponse = ReadLine();
+                if (!pwResponse.empty()) {
+                    bool authOk = false;
+                    try {
+                        auto j = nlohmann::json::parse(pwResponse);
+                        auto it = j.find("Coalition");
+                        if (it != j.end() && it->is_number_integer())
+                            authOk = (it->get<int>() != 0);
+                    } catch (...) {
+                        LogI("Failed to parse EAM response — treating as failed");
+                    }
+                    if (authOk) {
+                        LogI("EAM auth succeeded for coalition=" + std::to_string(coalition));
+                    } else {
+                        LogI("EAM auth failed for coalition=" + std::to_string(coalition));
+                        return false;
+                    }
+                } else {
+                    LogI("No EAM response (timeout/error) — handshake failed");
+                    return false;
+                }
+            } else {
+                LogI("Server does not have EAM enabled — skipping password");
+            }
+        }
     }
 
     LogI("Handshake OK coalition=" + std::to_string(coalition) + " name=" + name);
     return true;
+}
+
+// ---------------------------------------------------------------------------
+// ReadLine — read a newline-delimited JSON line from TCP with 2s timeout
+// ---------------------------------------------------------------------------
+std::string SRSClient::ReadLine() {
+    // Set receive timeout (2 seconds)
+    DWORD timeoutMs = 2000;
+    setsockopt(m_tcp, SOL_SOCKET, SO_RCVTIMEO,
+               reinterpret_cast<const char*>(&timeoutMs), sizeof(timeoutMs));
+
+    std::string line;
+    char ch;
+    while (true) {
+        int n = recv(m_tcp, &ch, 1, 0);
+        if (n <= 0) {
+            // Timeout or error
+            line.clear();
+            break;
+        }
+        if (ch == '\n') break;
+        line.push_back(ch);
+    }
+
+    // Restore infinite timeout (set to 0 = default blocking)
+    timeoutMs = 0;
+    setsockopt(m_tcp, SOL_SOCKET, SO_RCVTIMEO,
+               reinterpret_cast<const char*>(&timeoutMs), sizeof(timeoutMs));
+
+    return line;
 }
 
 void SRSClient::SendPing() {

--- a/src/backends/srs/srs_client.h
+++ b/src/backends/srs/srs_client.h
@@ -27,9 +27,12 @@ public:
     // Connect TCP + UDP sockets to host:port.
     bool Connect(const std::string& host, int port);
 
-    // Send MessageSync + MessageExternalAWACSModePassword over TCP.
+    // Two-step handshake: send SYNC (MsgType=2), read server response,
+    // conditionally send EAM password if server has EAM enabled.
+    // eamPassword is the password for the desired coalition (empty = don't send).
     bool Handshake(int coalition, const std::string& name,
-                   const std::vector<FreqMod>& freqs);
+                   const std::vector<FreqMod>& freqs,
+                   const std::string& eamPassword = "");
 
     // Send a UDP ping (22-byte GUID) to keep the connection alive.
     void SendPing();
@@ -75,6 +78,10 @@ public:
                                         double lat, double lon, double alt) const;
 
 private:
+    // Read one newline-delimited JSON response from TCP (with 5s timeout).
+    // Returns empty string on error or timeout.
+    std::string ReadLine();
+
     SOCKET      m_tcp       = INVALID_SOCKET;
     SOCKET      m_udp       = INVALID_SOCKET;
     std::string m_host;

--- a/src/lua_tts.cpp
+++ b/src/lua_tts.cpp
@@ -157,17 +157,19 @@ int l_textToSpeech(lua_State* L) {
     req.message     = message;
 
     // Transmission params (arg 2)
-    req.srsHost     = GetTableString(L, 2, "host",        "localhost");
-    req.srsPort     = GetTableInt   (L, 2, "port",        5002);
-    req.freqs       = GetTableString(L, 2, "freqs",       "251");
-    req.modulations = GetTableString(L, 2, "modulations", "AM");
-    req.coalition   = GetTableInt   (L, 2, "coalition",   0);
-    req.name        = GetTableString(L, 2, "name",        "HoundTTS");
-    req.encrypt     = GetTableBool  (L, 2, "encrypt",     false);
-    req.encKey      = GetTableInt   (L, 2, "encKey",      0);
-    req.lat         = GetTableNumber(L, 2, "lat",         91.0);
-    req.lon         = GetTableNumber(L, 2, "lon",         181.0);
-    req.alt         = GetTableNumber(L, 2, "alt",         -500.0);
+    req.srsHost          = GetTableString(L, 2, "host",               "localhost");
+    req.srsPort          = GetTableInt   (L, 2, "port",               5002);
+    req.freqs            = GetTableString(L, 2, "freqs",              "251");
+    req.modulations      = GetTableString(L, 2, "modulations",        "AM");
+    req.coalition        = GetTableInt   (L, 2, "coalition",          0);
+    req.name             = GetTableString(L, 2, "name",               "HoundTTS");
+    req.encrypt          = GetTableBool  (L, 2, "encrypt",            false);
+    req.encKey           = GetTableInt   (L, 2, "encKey",             0);
+    req.srsBluePassword  = GetTableString(L, 2, "srs_blue_password",  "");
+    req.srsRedPassword   = GetTableString(L, 2, "srs_red_password",   "");
+    req.lat              = GetTableNumber(L, 2, "lat",                91.0);
+    req.lon              = GetTableNumber(L, 2, "lon",                181.0);
+    req.alt              = GetTableNumber(L, 2, "alt",                -500.0);
 
     // Provider params (arg 3)
     req.provider    = provider;  // enum
@@ -202,18 +204,20 @@ int l_textToSpeech(lua_State* L) {
 
     // Build TransmitParams from the request (pure routing — no TTS logic)
     HoundTTS::TransmitParams txParams;
-    txParams.host        = req.srsHost.empty() ? "127.0.0.1" : req.srsHost;
-    txParams.port        = req.srsPort;
-    txParams.freqs       = req.freqs;
-    txParams.modulations = req.modulations;
-    txParams.encrypt     = req.encrypt;
-    txParams.encKey      = static_cast<uint8_t>(req.encKey);
-    txParams.coalition   = req.coalition;
-    txParams.name        = req.name;
-    txParams.lat         = req.lat;
-    txParams.lon         = req.lon;
-    txParams.alt         = req.alt;
-    txParams.session     = session;
+    txParams.host            = req.srsHost.empty() ? "127.0.0.1" : req.srsHost;
+    txParams.port            = req.srsPort;
+    txParams.freqs           = req.freqs;
+    txParams.modulations     = req.modulations;
+    txParams.encrypt         = req.encrypt;
+    txParams.encKey          = static_cast<uint8_t>(req.encKey);
+    txParams.coalition       = req.coalition;
+    txParams.name            = req.name;
+    txParams.srsBluePassword = req.srsBluePassword;
+    txParams.srsRedPassword  = req.srsRedPassword;
+    txParams.lat             = req.lat;
+    txParams.lon             = req.lon;
+    txParams.alt             = req.alt;
+    txParams.session         = session;
 
     // Shared PCM queue: pipeline produces, backend consumes
     auto pcmQueue = std::make_shared<HoundTTS::PCMQueue>();
@@ -311,17 +315,19 @@ int l_startNoise(lua_State* L) {
     luaL_checktype(L, 2, LUA_TTABLE);  // noiseParams
 
     // Transmission params
-    std::string transmitter = GetTableString(L, 1, "transmitter", "srs");
-    std::string host        = GetTableString(L, 1, "host",        "localhost");
-    int         port        = GetTableInt   (L, 1, "port",        5002);
-    std::string freqs       = GetTableString(L, 1, "freqs",       "251.0");
-    std::string modulations = GetTableString(L, 1, "modulations", "AM");
-    int         coalition   = GetTableInt   (L, 1, "coalition",   0);
-    std::string name        = GetTableString(L, 1, "name",        "HoundTTS-Jammer");
+    std::string transmitter       = GetTableString(L, 1, "transmitter",       "srs");
+    std::string host              = GetTableString(L, 1, "host",              "localhost");
+    int         port              = GetTableInt   (L, 1, "port",              5002);
+    std::string freqs             = GetTableString(L, 1, "freqs",             "251.0");
+    std::string modulations       = GetTableString(L, 1, "modulations",       "AM");
+    int         coalition         = GetTableInt   (L, 1, "coalition",         0);
+    std::string name              = GetTableString(L, 1, "name",              "HoundTTS-Jammer");
+    std::string srsBluePassword   = GetTableString(L, 1, "srs_blue_password", "");
+    std::string srsRedPassword    = GetTableString(L, 1, "srs_red_password",  "");
     // encrypt/encKey intentionally not read from Lua — noise is never encrypted
-    double      lat         = GetTableNumber(L, 1, "lat",         91.0);
-    double      lon         = GetTableNumber(L, 1, "lon",         181.0);
-    double      alt         = GetTableNumber(L, 1, "alt",         -500.0);
+    double      lat               = GetTableNumber(L, 1, "lat",               91.0);
+    double      lon               = GetTableNumber(L, 1, "lon",               181.0);
+    double      alt               = GetTableNumber(L, 1, "alt",               -500.0);
 
     // Noise params
     std::string noiseType  = GetTableString(L, 2, "noiseType",  "white");
@@ -359,18 +365,20 @@ int l_startNoise(lua_State* L) {
 
     // Build TransmitParams
     HoundTTS::TransmitParams txParams;
-    txParams.host        = host.empty() ? "127.0.0.1" : host;
-    txParams.port        = port;
-    txParams.freqs       = expandedFreqs;
-    txParams.modulations = expandedMods;
-    txParams.encrypt     = false;  // noise is never encrypted (encryption would just garble the noise)
-    txParams.encKey      = 0;
-    txParams.coalition   = coalition;
-    txParams.name        = name;
-    txParams.lat         = lat;
-    txParams.lon         = lon;
-    txParams.alt         = alt;
-    txParams.session     = session;
+    txParams.host            = host.empty() ? "127.0.0.1" : host;
+    txParams.port            = port;
+    txParams.freqs           = expandedFreqs;
+    txParams.modulations     = expandedMods;
+    txParams.encrypt         = false;  // noise is never encrypted (encryption would just garble the noise)
+    txParams.encKey          = 0;
+    txParams.coalition       = coalition;
+    txParams.name            = name;
+    txParams.srsBluePassword = srsBluePassword;
+    txParams.srsRedPassword  = srsRedPassword;
+    txParams.lat             = lat;
+    txParams.lon             = lon;
+    txParams.alt             = alt;
+    txParams.session         = session;
 
     // Shared PCM queue: noise generator produces, backend consumes
     auto pcmQueue = std::make_shared<HoundTTS::PCMQueue>();
@@ -406,17 +414,19 @@ int l_startTone(lua_State* L) {
     luaL_checktype(L, 2, LUA_TTABLE);  // toneParams
 
     // Transmission params
-    std::string transmitter = GetTableString(L, 1, "transmitter", "srs");
-    std::string host        = GetTableString(L, 1, "host",        "localhost");
-    int         port        = GetTableInt   (L, 1, "port",        5002);
-    std::string freqs       = GetTableString(L, 1, "freqs",       "251.0");
-    std::string modulations = GetTableString(L, 1, "modulations", "AM");
-    int         coalition   = GetTableInt   (L, 1, "coalition",   0);
-    std::string name        = GetTableString(L, 1, "name",        "HoundTTS-Tone");
+    std::string transmitter       = GetTableString(L, 1, "transmitter",       "srs");
+    std::string host              = GetTableString(L, 1, "host",              "localhost");
+    int         port              = GetTableInt   (L, 1, "port",              5002);
+    std::string freqs             = GetTableString(L, 1, "freqs",             "251.0");
+    std::string modulations       = GetTableString(L, 1, "modulations",       "AM");
+    int         coalition         = GetTableInt   (L, 1, "coalition",         0);
+    std::string name              = GetTableString(L, 1, "name",              "HoundTTS-Tone");
+    std::string srsBluePassword   = GetTableString(L, 1, "srs_blue_password", "");
+    std::string srsRedPassword    = GetTableString(L, 1, "srs_red_password",  "");
     // encrypt/encKey intentionally not read from Lua — tone is never encrypted
-    double      lat         = GetTableNumber(L, 1, "lat",         91.0);
-    double      lon         = GetTableNumber(L, 1, "lon",         181.0);
-    double      alt         = GetTableNumber(L, 1, "alt",         -500.0);
+    double      lat               = GetTableNumber(L, 1, "lat",               91.0);
+    double      lon               = GetTableNumber(L, 1, "lon",               181.0);
+    double      alt               = GetTableNumber(L, 1, "alt",               -500.0);
 
     // Tone params
     double duration = GetTableNumber(L, 2, "duration", 2.0);
@@ -436,18 +446,20 @@ int l_startTone(lua_State* L) {
 
     // Build TransmitParams
     HoundTTS::TransmitParams txParams;
-    txParams.host        = host.empty() ? "127.0.0.1" : host;
-    txParams.port        = port;
-    txParams.freqs       = freqs;
-    txParams.modulations = modulations;
-    txParams.encrypt     = false; // Tone should not be encrypted
-    txParams.encKey      = 0;
-    txParams.coalition   = coalition;
-    txParams.name        = name;
-    txParams.lat         = lat;
-    txParams.lon         = lon;
-    txParams.alt         = alt;
-    txParams.session     = session;
+    txParams.host            = host.empty() ? "127.0.0.1" : host;
+    txParams.port            = port;
+    txParams.freqs           = freqs;
+    txParams.modulations     = modulations;
+    txParams.encrypt         = false; // Tone should not be encrypted
+    txParams.encKey          = 0;
+    txParams.coalition       = coalition;
+    txParams.name            = name;
+    txParams.srsBluePassword = srsBluePassword;
+    txParams.srsRedPassword  = srsRedPassword;
+    txParams.lat             = lat;
+    txParams.lon             = lon;
+    txParams.alt             = alt;
+    txParams.session         = session;
 
     auto pcmQueue = std::make_shared<HoundTTS::PCMQueue>();
     std::unique_ptr<HoundTTS::ITTSBackend> backend(MakeBackend(transmitter));


### PR DESCRIPTION
Adds SRS_BLUE_PASSWORD / SRS_RED_PASSWORD config options for servers with --enableEAM active. Implements proper two-step handshake:

1. Send SYNC (MsgType=2), read server response
2. If EAM enabled and password configured, send EXTERNAL_AWACS_MODE_PASSWORD (MsgType=7) with the correct coalition password
3. Read auth response, log success/failure

Only reads server SYNC response when a password is configured (zero latency added for the common no-EAM case). Passwords flow through HoundTTS.lua -> Lua bridge -> TTSRequest -> TransmitParams -> SRSBackend -> SRSClient::Handshake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for separate blue and red SRS External AWACS Mode passwords.
  * Transmission flows can now use coalition-specific credentials automatically.
  * Lua-based text, noise, and tone transmissions now accept optional password overrides.

* **Bug Fixes**
  * Improved SRS connection setup to handle EAM-enabled servers more reliably.
  * Added safer handshake behavior when EAM is not enabled or credentials are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->